### PR TITLE
Define category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,7 @@ author=zix99
 maintainer=zix99
 sentence=Send messages between devices using ubsub.io
 paragraph=A platform for communicating between devices and services via ubsub.io
+category=Communication
 url=https://github.com/ubsub/ubsub-iot
 repository=https://github.com/ubsub/ubsub-iot.git
 architectures=esp8266,esp32,particle-photon


### PR DESCRIPTION
Lack of category property causes the Arduino IDE to show a warning on every compilation:

WARNING: Category '' in library ubsub is not valid. Setting to 'Uncategorized'